### PR TITLE
Update tipsi-stripe.podspec

### DIFF
--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '~> 16.0.0'
+  s.dependency 'Stripe', '~> 17.0.3'
 end


### PR DESCRIPTION
Hello, 

Petit update pour être compatible **Xcode 11.5**
En attendant que l'on bascule sur la branche officiel de tipsi-stripe (prévu asap avec rn 0.60)

Merci